### PR TITLE
Fix looping error on Redhat Network Routes

### DIFF
--- a/templates/route-RedHat.erb
+++ b/templates/route-RedHat.erb
@@ -2,5 +2,5 @@
 ### File managed by Puppet
 ###
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
-<%= @ipaddress[id] %>/<%= @netmask[id] %> via <%= @gateway[id] %> dev <%= @interface %><%- if @table -%> table <%= @table[id] %><%- end -%>
+<%= @ipaddress[id] %>/<%= @netmask[id] %> via <%= @gateway[id] %> dev <%= @interface %><%- if @table -%> table <%= @table[id] %><% end %>
 <%- end %>


### PR DESCRIPTION
Fixed the erb syntax to ensure a new line is added in to the relevant network scripts after each static route.